### PR TITLE
Add more sources and refine prompts

### DIFF
--- a/forecast.py
+++ b/forecast.py
@@ -79,7 +79,8 @@ def summarise():
     items = json.load(open(infile))
     text = "\n".join(f"- {i['title']} ({i['link']})" for i in items)
     prompt = (
-        "Condense the following items into ≤10 clear bullet points:\n" + text
+        "Condense the following items into ≤10 clear bullet points, "
+        "highlighting any financial, economic, or scientific insights:\n" + text
     )
     key = os.getenv("OPENAI_API_KEY", "").strip().strip('"')
     if not key:
@@ -114,8 +115,8 @@ def predict():
         return
     summary = open(infile).read()
     prompt = (
-        "From the summary below, generate at least three testable predictions with explicit"
-        " confidence levels (as percentages):\n" + summary
+        "From the summary below, generate at least three testable financial or market "
+        "predictions with explicit confidence levels (as percentages):\n" + summary
     )
     key = os.getenv("OPENAI_API_KEY", "").strip().strip('"')
     if not key:

--- a/sources.yaml
+++ b/sources.yaml
@@ -5,3 +5,13 @@
 
 # Use this feed for a demo/test:
 - https://www.noahpinion.blog/feed
+# General news
+- https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml
+# Financial & economics
+- https://www.marketwatch.com/rss/topstories
+- https://feeds.a.dj.com/rss/RSSMarketsMain.xml
+- https://www.cnbc.com/id/100003114/device/rss/rss.html
+# Science & technology
+- https://www.sciencedaily.com/rss/top/science.xml
+- https://www.nature.com/feeds/news.rss
+- https://news.ycombinator.com/rss


### PR DESCRIPTION
## Summary
- expand `sources.yaml` with additional news, finance and science feeds
- refine summarise prompt to emphasise financial, economic and scientific points
- ask for financial or market predictions in the predict prompt

## Testing
- `pytest -q`
- `python -m py_compile forecast.py`


------
