### PR TITLE
feat: structured JSON pipeline + reasoning mode hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ brain_state.json
 __pycache__/
 *.pyc
 .DS_Store
+.cache/


### PR DESCRIPTION
- Predict now outputs strict JSON (schema: text, category, horizon_days, deadline, confidence_pct, log_odds?, verification_criteria, evidence, monitoring_signals, supersedes_id?, rationale?)\n- IDs assigned in code; confidence_bin derived\n- Review returns JSON assessments + prose analysis; outcomes auto-updated; assessments saved\n- Summaries produce JSON with tags and render MD bullets\n- Added system prompts, medium reasoning, low temperature via FORESIGHT_LLM_TEMPERATURE\n- Added caching + retries; .cache ignored\n- Dashboard/newsletter compatible with new fields (confidence_pct)\n- Kept old formats backward-compatible where needed