### PR TITLE
chore: default to gpt-5.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,8 @@
 # Required for summarisation & prediction
 OPENAI_API_KEY=your_openai_api_key_here
 
+# Optional: override the default model (defaults to gpt-5.2)
+FORESIGHT_LLM_MODEL=gpt-5.2
+
 # Required for automatic self-update PRs (optional)
 GITHUB_TOKEN=your_github_token_here

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ but “Foresight Forge” felt the most distinctive and memorable.
    ```ini
    OPENAI_API_KEY=your_openai_api_key_here
    GITHUB_TOKEN=your_github_token_here
+   FORESIGHT_LLM_MODEL=gpt-5.2
    ```
 3. Populate `sources.yaml` with one URL per line of a news/RSS feed you want to track.
 4. (Optional) To publish the dashboard via GitHub Pages, enable Pages in repo settings and select the `docs/` folder on the `main` branch.

--- a/forecast.py
+++ b/forecast.py
@@ -23,7 +23,7 @@ from openai import OpenAI, OpenAIError
 # models in the future.
 # ---------------------------------------------------------------------------
 
-DEFAULT_LLM_MODEL = os.getenv("FORESIGHT_LLM_MODEL", "gpt-5")
+DEFAULT_LLM_MODEL = os.getenv("FORESIGHT_LLM_MODEL", "gpt-5.2")
 # GPT-5 reasoning models only support default temperature=1.0; set 1 by default
 DEFAULT_TEMPERATURE = float(os.getenv("FORESIGHT_LLM_TEMPERATURE", "1"))
 from git import Repo


### PR DESCRIPTION
- Set pipeline default model to gpt-5.2\n- Document FORESIGHT_LLM_MODEL override in .env.example and README