### PR TITLE
chore: bd sync metadata

### DIFF
--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,4 @@
+{
+  "database": "beads.db",
+  "jsonl_export": "issues.jsonl"
+}


### PR DESCRIPTION
Commits bd sync artifacts (.beads/metadata.json, .beads/interactions.jsonl) after closing issue foresight-forge-qcq.